### PR TITLE
Uneven legend scale

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -21,7 +21,7 @@
     </div>
     <div ng-if="vis.params.mapType !== 'Heatmap'" class="form-group">
       <div class="form-group">
-        <label>Quantize scale type</label>
+        <label>Legend scale type</label>
         <select name="scaleType"
           class="form-control"
           ng-model="vis.params.scaleType"
@@ -30,8 +30,20 @@
           >
         </select>
       </div>
-      <div ng-if="vis.params.scaleType === 'static'" class="form-group">
+      <div ng-if="vis.params.scaleType === 'Static'" class="form-group">
         <bands bands="vis.params.scaleBands"></bands>
+      </div>
+      <div ng-if="vis.params.scaleType === 'Dynamic - Linear'" class="form-group">
+        <div>
+          A legend scale which linearly grows from minimum to maximum range.
+        </div>
+      </div>
+      <div ng-if="vis.params.scaleType === 'Dynamic - Uneven'" class="form-group">
+        <div>
+          A legend scale that will create uneven ranges for the legend in an attempt
+          to split the map features uniformly across the ranges.  Useful when data is unevenly
+          distributed across the minimum - maximum range.
+        </div>
       </div>
     </div>
     <div ng-if="vis.params.mapType === 'Heatmap'" class="form-group">

--- a/public/options.html
+++ b/public/options.html
@@ -21,7 +21,11 @@
     </div>
     <div ng-if="vis.params.mapType !== 'Heatmap'" class="form-group">
       <div class="form-group">
-        <label>Legend scale type</label>
+        <label>
+          Legend scale type
+          <kbn-info ng-if="vis.params.scaleType === 'Dynamic - Linear'" info="A legend scale which linearly grows from minimum to maximum range."></kbn-info>
+          <kbn-info ng-if="vis.params.scaleType === 'Dynamic - Uneven'" info="A legend scale that will create uneven ranges for the legend in an attempt to split the map features uniformly across the ranges.  Useful when data is unevenly distributed across the minimum - maximum range."></kbn-info>
+        </label>
         <select name="scaleType"
           class="form-control"
           ng-model="vis.params.scaleType"
@@ -32,18 +36,6 @@
       </div>
       <div ng-if="vis.params.scaleType === 'Static'" class="form-group">
         <bands bands="vis.params.scaleBands"></bands>
-      </div>
-      <div ng-if="vis.params.scaleType === 'Dynamic - Linear'" class="form-group">
-        <div>
-          A legend scale which linearly grows from minimum to maximum range.
-        </div>
-      </div>
-      <div ng-if="vis.params.scaleType === 'Dynamic - Uneven'" class="form-group">
-        <div>
-          A legend scale that will create uneven ranges for the legend in an attempt
-          to split the map features uniformly across the ranges.  Useful when data is unevenly
-          distributed across the minimum - maximum range.
-        </div>
       </div>
     </div>
     <div ng-if="vis.params.mapType === 'Heatmap'" class="form-group">

--- a/public/vis.js
+++ b/public/vis.js
@@ -25,7 +25,7 @@ define(function (require) {
         defaults: {
           mapType: 'Scaled Circle Markers',
           collarScale: 1.5,
-          scaleType: 'dynamic',
+          scaleType: 'Dynamic - Linear',
           scaleBands: [{
             low: 0,
             high: 10,
@@ -49,7 +49,7 @@ define(function (require) {
           wms: config.get('visualization:tileMap:WMSdefaults')
         },
         mapTypes: ['Scaled Circle Markers', 'Shaded Circle Markers', 'Shaded Geohash Grid', 'Heatmap'],
-        scaleTypes: ['dynamic', 'static'],
+        scaleTypes: ['Dynamic - Linear', 'Dynamic - Uneven', 'Static'],
         canDesaturate: !!supports.cssFilters,
         editor: require('plugins/enhanced_tilemap/options.html')
       },

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -321,6 +321,9 @@ define(function (require) {
      * return {undefined}
      */
     BaseMarker.prototype.quantizeLegendColors = function () {
+      let reds1 = ['#ff6128'];
+      let reds3 = ['#fecc5c', '#fd8d3c', '#e31a1c'];
+      let reds5 = ['#fed976', '#feb24c', '#fd8d3c', '#f03b20', '#bd0026'];
       if ('Static' === this._attr.scaleType) {
         const domain = [];
         const colors = [];
@@ -330,14 +333,11 @@ define(function (require) {
         });
         this._legendColors = colors;
         this._legendQuantizer = d3.scale.threshold().domain(domain).range(this._legendColors);
-      } else {
+      } else if('Dynamic - Linear' == this._attr.scaleType) {
         let min = _.get(this.geoJson, 'properties.allmin', 0);
         let max = _.get(this.geoJson, 'properties.allmax', 1);
         let quantizeDomain = (min !== max) ? [min, max] : d3.scale.quantize().domain();
 
-        let reds1 = ['#ff6128'];
-        let reds3 = ['#fecc5c', '#fd8d3c', '#e31a1c'];
-        let reds5 = ['#fed976', '#feb24c', '#fd8d3c', '#f03b20', '#bd0026'];
         let bottomCutoff = 2;
         let middleCutoff = 24;
 
@@ -348,35 +348,41 @@ define(function (require) {
         } else {
           this._legendColors = reds5;
         }
+        this._legendQuantizer = d3.scale.quantize().domain(quantizeDomain).range(this._legendColors);
 
-        if('Dynamic - Linear' === this._attr.scaleType) {
-          this._legendQuantizer = d3.scale.quantize().domain(quantizeDomain).range(this._legendColors);
-        } else { // Dynamic - Uneven
-          // A legend scale that will create uneven ranges for the legend in an attempt
-          // to split the map features uniformly across the ranges.  Useful when data is unevenly
-          // distributed across the minimum - maximum range.
-          let features = this.geoJson.features;
-          features.sort(function(x, y) {
-            return d3.ascending(x.properties.value, y.properties.value);
-          });
-          let featureLength = features.length;
-          let count = 0;
-          let ranges = [];
-          let max = 0;
-          let bands = this._legendColors.length;
-          features.forEach(function(obj) {
-            max = Math.max(max, obj.properties.value);
-            count++;
-            if(count >= featureLength/bands) {
-              count = 0;
-              ranges.push(obj.properties.value);
-            }
-          });
-          if(ranges.length < bands) {
-            ranges.push(max);
-          }
-          this._legendQuantizer = d3.scale.threshold().domain(ranges).range(this._legendColors);
+      } else { // Dynamic - Uneven
+        // A legend scale that will create uneven ranges for the legend in an attempt
+        // to split the map features uniformly across the ranges.  Useful when data is unevenly
+        // distributed across the minimum - maximum range.
+        let features = this.geoJson.features;
+        let featureLength = features.length;
+        features.sort(function(x, y) {
+          return d3.ascending(x.properties.value, y.properties.value);
+        });
+
+        let bottomCutoff = 1;
+        let middleCutoff = 9;
+        if (featureLength <= bottomCutoff) {
+          this._legendColors = reds1;
+        } else if (featureLength <= middleCutoff) {
+          this._legendColors = reds3;
+        } else {
+          this._legendColors = reds5;
         }
+
+        let ranges = [];
+        let bands = this._legendColors.length;
+        for(let i=1; i<bands; i++) {
+          let index = Math.round(i*featureLength/bands);
+          if(index <= featureLength - 1) {
+            ranges.push(features[index].properties.value);
+          }
+        };
+        if(ranges.length < bands) {
+          let max = _.get(this.geoJson, 'properties.allmax', 1);
+          ranges.push(max);
+        }
+        this._legendQuantizer = d3.scale.threshold().domain(ranges).range(this._legendColors);
       }
     };
 

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -199,8 +199,6 @@ define(function (require) {
      */
     BaseMarker.prototype._createMarkerGroup = function (options) {
       let self = this;
-
-
       let defaultOptions = {
         onEachFeature: function (feature, layer) {
           self.bindPopup(feature, layer);

--- a/public/vislib/marker_types/base_marker.js
+++ b/public/vislib/marker_types/base_marker.js
@@ -57,8 +57,7 @@ define(function (require) {
 
           let icon = $('<i>').css({
             background: color,
-            'border-color': self.darkerColor(color),
-            'opacitiy': 0.75
+            'border-color': self.darkerColor(color)
           });
 
           label.append(icon);

--- a/public/vislib/marker_types/scaled_circles.js
+++ b/public/vislib/marker_types/scaled_circles.js
@@ -83,7 +83,7 @@ define(function (require) {
     }
 
     /**
-     * _scaleValueBewteen returns the given value between the new min and max based
+     * _scaleValueBetween returns the given value between the new min and max based
      * on the original scale
      *
      * @method _scaleValueBetween
@@ -91,7 +91,7 @@ define(function (require) {
      * @param min {Number} - The new minimum
      * @param max {Number} - The new maximum
      * @param orgMin {Number} - The original minimum
-     * @param feature {Number} - The original maximum
+     * @param orgMax {Number} - The original maximum
      * @return {Number}
      */
     ScaledCircleMarker.prototype._scaleValueBetween = function(value, min, max, orgMin, orgMax) {


### PR DESCRIPTION
Fixes #22 

With linear scaled legend
<img width="514" alt="screen shot 2016-12-19 at 10 25 56 am" src="https://cloud.githubusercontent.com/assets/5314322/21322823/0bd6b3d4-c5d8-11e6-91eb-5ab9d390c82a.png">

With uneven scaled legend
<img width="514" alt="screen shot 2016-12-19 at 10 26 14 am" src="https://cloud.githubusercontent.com/assets/5314322/21322813/f80faa04-c5d7-11e6-835f-3cf6e517122e.png">

Both dynamic options now describe how it affects the legend.
