### PR TITLE
div.rightCorner css fixed

### DIFF
--- a/public/vis.less
+++ b/public/vis.less
@@ -51,6 +51,12 @@
 ul.etm-options-list {
   list-style:none;
   padding-left:0;
+
+  div.rightCorner {
+    position: absolute;
+    right: 0px;
+    top: 0px;
+  }
 }
 
 li.etm-option-item {
@@ -58,12 +64,6 @@ li.etm-option-item {
   margin: 0px 5px 2px 5px;
   padding: 2px;
   position: relative;
-}
-
-div.rightCorner {
-  position: absolute;
-  right: 0px;
-  top: 0px;
 }
 
 .etm-vis .leaflet-popup-content-wrapper {


### PR DESCRIPTION
Part of https://github.com/nreese/enhanced_tilemap/issues/47 
This PR fixes remove button layout problem in Kibi
Before
![before](https://cloud.githubusercontent.com/assets/15969928/25697729/c9e63d02-30c4-11e7-9582-f3248894daa3.png)
After
![after](https://cloud.githubusercontent.com/assets/15969928/25697736/d1ac09cc-30c4-11e7-9bb6-3fcecc677388.png)

Also checked plugin buttons, their layout seems ok.
![checked](https://cloud.githubusercontent.com/assets/15969928/25697757/e82dab56-30c4-11e7-9d05-0c790c861ec4.png)

