### PR TITLE
possibility to display values of index nested fields in the POI's tooltip

### DIFF
--- a/public/POIs.js
+++ b/public/POIs.js
@@ -155,8 +155,17 @@ define(function (require) {
 
     POIs.prototype._popupContent = function (hit) {
       let dlContent = '';
+      const nestedField = function (object, field) {
+        const isNested = field.split('.').length > 1;
+        if (isNested === false){
+          return object[field]
+        }
+        const nestedFieldsArray = field.split('.');
+        const firstField = nestedFieldsArray.splice(0, 1);
+        return nestedField(object[firstField], nestedFieldsArray.join('.'));
+      }
       this.popupFields.forEach(function(field) {
-        dlContent += `<dt>${field}</dt><dd>${hit._source[field]}</dd>`
+        dlContent += `<dt>${field}</dt><dd>${nestedField(hit._source,field)}</dd>`
       });
       return `<dl>${dlContent}</dl>`;
     }


### PR DESCRIPTION
For the POI's layer of this pluggin, if you try to add fields to the tooltip, it works only in the cases that the field is only in the 'root' of the document, if not, it displays undefined. The reason is:

When you have field names like eventMessage.event.name, and you try to get the value of this field in the line 'dlContent += `<dt>${field}</dt><dd>${hit._source[field]}</dd>'

You get hit._source['eventMessage.event.name'], because kibana gives you that field name, and there is not key like that. Instead, the value must be gotten using the expression:
hit._source['eventMessage']['event']['name']
For this reason I added the function nestedField, that checks if the field has dots, and for each one, access to the property of the _source object one be one.


![image](https://user-images.githubusercontent.com/7641886/31620871-ac0f76ee-b298-11e7-977b-8a38db0dae11.png)

